### PR TITLE
ci: add build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        shell: pwsh
+        run: |
+          pip install sphinx
+          pip install solar-theme
+          .\docs\make.bat html
+      - name: Publish
+        if: github.ref == 'refs/heads/master'
+        shell: pwsh
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        run: |
+          git clone --single-branch --branch master "https://$ENV:API_TOKEN_GITHUB@github.com/DFIR-ORC/dfir-orc.github.io.git"
+          Copy-Item -Force -Recurse .\docs\build\html\* dfir-orc.github.io/
+          cd dfir-orc.github.io/
+          git add --all
+          git status
+          git -c "user.name=dfir-orc-bot" -c "user.email=73876579+dfir-orc-bot@users.noreply.github.com" commit -m "Update by GitHub Action"
+          git push


### PR DESCRIPTION
- Build pull request to be merged in master.
- Push generated documentation into 'dfir-orc.github.io' master branch.

To be able to push the API_TOKEN_GITHUB secret variable must be defined
with a GitHub user's "Personal access token".

How to create a "Personal access token":
- Login / Settings / Developer settings / Personal access tokens /
    Generate new token
- Name: API_TOKEN_GITHUB
- Checkboxes: "root box" of repositories permission

Register the token:
- Connect to "dfir-orc-doc-src" repository / [project] Settings /
    New secret > API_TOKEN_GITHUB (check paste formatting for spaces)

BEWARE: The generated 'Personal access token' grants all user's rights.
Create a dedicated user for the target repository.